### PR TITLE
fixed overflow bug while involke send, then communication_latency mig…

### DIFF
--- a/congestion_unaware/api/SendRecvTrackingMap.cc
+++ b/congestion_unaware/api/SendRecvTrackingMap.cc
@@ -99,8 +99,6 @@ void Analytical::SendRecvTrackingMap::insert_send(
     int dest,
     PayloadSize count,
     AstraSim::timespec_t send_finish_time) noexcept {
-  bool duplicate_found = false;
-
   Key key = make_tuple(tag, src, dest, count);
 
   send_recv_tracking_map.emplace(

--- a/congestion_unaware/topology/HierarchicalTopology.cc
+++ b/congestion_unaware/topology/HierarchicalTopology.cc
@@ -174,7 +174,7 @@ pair<double, int> HierarchicalTopology::send(
   }
 
   // use that dimension
-  auto communication_latency = 0;
+  auto communication_latency = 0ul;
   auto topology = hierarchy_config.getTopologyForDim(dim);
 
   if (topology == TopologyList::Ring) {


### PR DESCRIPTION
fixed bug in unaware/topology/HierarchicalTopology.cc:send().

The `auto communication_latency` will be inferred has type `int` as the init value of it is 0, which might overflow, causing negative comm_latency and result a trans latency=0. Change 0 to 0ul to avoid the bug.

deleted the unused variable `duplicate_found`